### PR TITLE
Publish -abstractions NuGet packages to GitHub NuGet repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       if: github.event_name == 'push' && startswith(github.ref, 'refs/heads')
       shell: bash
       run:  |
-         OWNER=${{GITHUB_REPOSITORY_OWNER}}
+         OWNER=$GITHUB_REPOSITORY_OWNER
          NUGET_REPO="https://nuget.pkg.github.com/$OWNER/index.json"
          dotnet nuget add source --username $OWNER --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "$NUGET_REPO"  
          dotnet nuget push 'build/output/*.nupkg' -s github -k ${{secrets.GITHUB_TOKEN}} --skip-duplicate --no-symbols true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,11 @@ jobs:
          NUGET_REPO="https://nuget.pkg.github.com/$OWNER/index.json"
          dotnet nuget add source --username $OWNER --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "$NUGET_REPO"  
          dotnet nuget push 'build/output/*.nupkg' -s github -k ${{secrets.GITHUB_TOKEN}} --skip-duplicate --no-symbols true
+  
   delete-stale-pre-release-packages:
     runs-on: ubuntu-18.04
     needs: build
+    if: github.event_name == 'push' && startswith(github.ref, 'refs/heads/main')
     strategy:
       matrix:
         # Is this list the same as the nuget packages generated in opensearch-net-abstractions repo?

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       name: Validate *.npkg files that were created
 
     - name: Publish packages to GitHub package repository
-      if: github.event_name == 'push' && startswith(github.ref, 'refs/heads')
+      if: github.event_name == 'push' && startswith(github.ref, 'refs/heads/main')
       shell: bash
       run:  |
          OWNER=$GITHUB_REPOSITORY_OWNER

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,4 +46,8 @@ jobs:
          NUGET_REPO="https://nuget.pkg.github.com/$OWNER/index.json"
          dotnet nuget add source --username $OWNER --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "$NUGET_REPO"  
          dotnet nuget push 'build/output/*.nupkg' -s github -k ${{secrets.GITHUB_TOKEN}} --skip-duplicate --no-symbols true
-    
+    - uses: actions/delete-package-versions@v3
+      with: 
+        package-name: 'OpenSearch.OpenSearch.Ephemeral'
+        min-versions-to-keep: 1
+        delete-only-pre-release-versions: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       if: github.event_name == 'push' && startswith(github.ref, 'refs/heads')
       shell: bash
       run:  |
-         OWNER=${{github.GITHUB_REPOSITORY_OWNER}}
+         OWNER=${{GITHUB_REPOSITORY_OWNER}}
          NUGET_REPO="https://nuget.pkg.github.com/$OWNER/index.json"
          dotnet nuget add source --username $OWNER --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "$NUGET_REPO"  
          dotnet nuget push 'build/output/*.nupkg' -s github -k ${{secrets.GITHUB_TOKEN}} --skip-duplicate --no-symbols true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,5 @@
-name: Always be deploying
-
+name: Build and publish snapshot packages
 on:
-  pull_request:
-    paths-ignore: 
-      - 'README.md'
-      - '.editorconfig'
   push:
     paths-ignore:
       - 'README.md'
@@ -28,12 +23,25 @@ jobs:
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '5.0.100'
-        
+  
+    - run: dotnet nuget add source --username Bit-Quill --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/Bit-Quill/index.json"  
+      name: Add GitHub NuGet Repository as a Package Source
     - run: ./build.sh build -s true
       name: Build
+
     - run: ./build.sh generatepackages -s true
       name: Generate local nuget packages
+
     - uses: actions/upload-artifact@v2
       with:
         name: nuget-packages
         path: build/output/*
+
+    - run: ./build.sh validatepackages -s true
+      name: "validate *.npkg files that were created"
+
+    - name: publish canary packages github package repository
+      #if: github.event_name == 'push' && startswith(github.ref, 'refs/heads')
+      shell: bash
+      run:  |
+         dotnet nuget push 'build/output/*Xunit*.nupkg' -s github -k ${{secrets.GITHUB_TOKEN}} --skip-duplicate --no-symbols true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,17 @@ jobs:
          NUGET_REPO="https://nuget.pkg.github.com/$OWNER/index.json"
          dotnet nuget add source --username $OWNER --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "$NUGET_REPO"  
          dotnet nuget push 'build/output/*.nupkg' -s github -k ${{secrets.GITHUB_TOKEN}} --skip-duplicate --no-symbols true
+  delete-stale-pre-release-packages:
+    runs-on: ubuntu-18.04
+    needs: build
+    strategy:
+      matrix:
+        # Is this list the same as the nuget packages generated in opensearch-net-abstractions repo?
+        package: [OpenSearch.OpenSearch.Ephemeral, OpenSearch.OpenSearch.Managed, OpenSearch.OpenSearch.Xunit, OpenSearch.Stack.ArtifactsApi]
+    steps:
     - uses: actions/delete-package-versions@v3
       with: 
-        package-name: 'OpenSearch.OpenSearch.Ephemeral'
+        package-name: ${{ matrix.package }}
         min-versions-to-keep: 1
         delete-only-pre-release-versions: "true"
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,6 @@ jobs:
       with:
         dotnet-version: '5.0.100'
   
-    # TODO: Update line below to match upstream.
-    - run: dotnet nuget add source --username Bit-Quill --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/Bit-Quill/index.json"  
-      name: Add GitHub NuGet Repository as a Package Source
     - run: ./build.sh build -s true
       name: Build
 
@@ -41,8 +38,12 @@ jobs:
     - run: ./build.sh validatepackages -s true
       name: Validate *.npkg files that were created
 
-    - name: Publish canary packages GitHub package repository
+    - name: Publish packages to GitHub package repository
       if: github.event_name == 'push' && startswith(github.ref, 'refs/heads')
       shell: bash
       run:  |
+         OWNER=${{github.GITHUB_REPOSITORY_OWNER}}
+         NUGET_REPO="https://nuget.pkg.github.com/$OWNER/index.json"
+         dotnet nuget add source --username $OWNER --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "$NUGET_REPO"  
          dotnet nuget push 'build/output/*.nupkg' -s github -k ${{secrets.GITHUB_TOKEN}} --skip-duplicate --no-symbols true
+    

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       with:
         dotnet-version: '5.0.100'
   
+    # TODO: Update line below to match upstream.
     - run: dotnet nuget add source --username Bit-Quill --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/Bit-Quill/index.json"  
       name: Add GitHub NuGet Repository as a Package Source
     - run: ./build.sh build -s true
@@ -38,10 +39,10 @@ jobs:
         path: build/output/*
 
     - run: ./build.sh validatepackages -s true
-      name: "validate *.npkg files that were created"
+      name: Validate *.npkg files that were created
 
-    - name: publish canary packages github package repository
-      #if: github.event_name == 'push' && startswith(github.ref, 'refs/heads')
+    - name: Publish canary packages GitHub package repository
+      if: github.event_name == 'push' && startswith(github.ref, 'refs/heads')
       shell: bash
       run:  |
-         dotnet nuget push 'build/output/*Xunit*.nupkg' -s github -k ${{secrets.GITHUB_TOKEN}} --skip-duplicate --no-symbols true
+         dotnet nuget push 'build/output/*.nupkg' -s github -k ${{secrets.GITHUB_TOKEN}} --skip-duplicate --no-symbols true

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,11 @@
     <Authors>OpenSearch Project and contributors</Authors>
     <Copyright>OpenSearch</Copyright>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/opensearch-project/opensearch-net-abstractions</RepositoryUrl>
+    <RepositoryUrl>https://github.com/Bit-Quill/opensearch-net-abstractions-1</RepositoryUrl>
+    <!-- Use the value below when merging to upstream.
+       <RepositoryUrl>https://github.com/opensearch-project/opensearch-net-abstractions</RepositoryUrl>
+    -->
+    <RepositoryType>Git</RepositoryType>
     <PackageProjectUrl>https://github.com/opensearch-project/opensearch-net-abstractions</PackageProjectUrl>
     <PackageReleaseNotes>https://github.com/opensearch-project/opensearch-net-abstractions/releases</PackageReleaseNotes>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,10 +5,7 @@
     <Authors>OpenSearch Project and contributors</Authors>
     <Copyright>OpenSearch</Copyright>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/Bit-Quill/opensearch-net-abstractions-1</RepositoryUrl>
-    <!-- Use the value below when merging to upstream.
-       <RepositoryUrl>https://github.com/opensearch-project/opensearch-net-abstractions</RepositoryUrl>
-    -->
+    <RepositoryUrl>https://github.com/opensearch-project/opensearch-net-abstractions</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageProjectUrl>https://github.com/opensearch-project/opensearch-net-abstractions</PackageProjectUrl>
     <PackageReleaseNotes>https://github.com/opensearch-project/opensearch-net-abstractions/releases</PackageReleaseNotes>

--- a/src/OpenSearch.OpenSearch.Xunit/OpenSearch.OpenSearch.Xunit.csproj
+++ b/src/OpenSearch.OpenSearch.Xunit/OpenSearch.OpenSearch.Xunit.csproj
@@ -4,7 +4,7 @@
     <IsPackable>True</IsPackable>
     <Description>Provides an Xunit test framework allowing you to run integration tests against local ephemeral OpenSearch clusters</Description>
     <PackageTags>opensearch,opensearch,xunit,cluster,integration,test,ephemeral</PackageTags>
-    <RepositoryUrl>https://www.github.com/Bit-Quill/opensearch-net-abstractions-1</RepositoryUrl>
+    <RepositoryUrl>https://github.com/Bit-Quill/opensearch-net-abstractions-1.git</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/OpenSearch.OpenSearch.Xunit/OpenSearch.OpenSearch.Xunit.csproj
+++ b/src/OpenSearch.OpenSearch.Xunit/OpenSearch.OpenSearch.Xunit.csproj
@@ -4,7 +4,7 @@
     <IsPackable>True</IsPackable>
     <Description>Provides an Xunit test framework allowing you to run integration tests against local ephemeral OpenSearch clusters</Description>
     <PackageTags>opensearch,opensearch,xunit,cluster,integration,test,ephemeral</PackageTags>
-    <RepositoryUrl>https://nuget.pkg.github.com/Bit-Quill/index.json</RepositoryUrl>
+    <RepositoryUrl>https://www.github.com/Bit-Quill/opensearch-net-abstractions-1</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
   </PropertyGroup>
   <ItemGroup>

--- a/src/OpenSearch.OpenSearch.Xunit/OpenSearch.OpenSearch.Xunit.csproj
+++ b/src/OpenSearch.OpenSearch.Xunit/OpenSearch.OpenSearch.Xunit.csproj
@@ -4,6 +4,7 @@
     <IsPackable>True</IsPackable>
     <Description>Provides an Xunit test framework allowing you to run integration tests against local ephemeral OpenSearch clusters</Description>
     <PackageTags>opensearch,opensearch,xunit,cluster,integration,test,ephemeral</PackageTags>
+    <RepositoryUrl>https://nuget.pkg.github.com/Bit-Quill/index.json</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/src/OpenSearch.OpenSearch.Xunit/OpenSearch.OpenSearch.Xunit.csproj
+++ b/src/OpenSearch.OpenSearch.Xunit/OpenSearch.OpenSearch.Xunit.csproj
@@ -5,6 +5,7 @@
     <Description>Provides an Xunit test framework allowing you to run integration tests against local ephemeral OpenSearch clusters</Description>
     <PackageTags>opensearch,opensearch,xunit,cluster,integration,test,ephemeral</PackageTags>
     <RepositoryUrl>https://nuget.pkg.github.com/Bit-Quill/index.json</RepositoryUrl>
+    <RepositoryType>Git</RepositoryType>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/src/OpenSearch.OpenSearch.Xunit/OpenSearch.OpenSearch.Xunit.csproj
+++ b/src/OpenSearch.OpenSearch.Xunit/OpenSearch.OpenSearch.Xunit.csproj
@@ -4,8 +4,6 @@
     <IsPackable>True</IsPackable>
     <Description>Provides an Xunit test framework allowing you to run integration tests against local ephemeral OpenSearch clusters</Description>
     <PackageTags>opensearch,opensearch,xunit,cluster,integration,test,ephemeral</PackageTags>
-    <RepositoryUrl>https://github.com/Bit-Quill/opensearch-net-abstractions-1.git</RepositoryUrl>
-    <RepositoryType>Git</RepositoryType>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.3.1" />


### PR DESCRIPTION
1. Updated ci.yml workflow to publish the packages.
2. Required to update RepositoryUrl for all packages so that GitHub accepts the packages.
3. Added a job to delete all but the most recent packages.
4. Packages are deleted and published only to commits to main branch.

### Additional Reviewers
@raymond-lum 
@alexmeizer 
@guiangumpac 
@Yury-Fridlyand 
